### PR TITLE
caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 - |
   flake8 .
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      conda build -c defaults -c conda-forge ./conda
+      travis_wait 30 conda build -c defaults -c conda-forge ./conda
   else
       # Workaround for Travis-CI bug #2: https://github.com/travis-ci/travis-ci/issues/7773
       conda build -c defaults -c conda-forge --no-test ./conda

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -27,7 +27,9 @@ test:
   source_files:
     - tests
   requires:
+    - aiohttp
     - pytest
+    - requests
   commands:
     - py.test --verbose
 

--- a/intake_geopandas/geopandas.py
+++ b/intake_geopandas/geopandas.py
@@ -141,8 +141,7 @@ class ShapefileSource(GeoPandasFileSource):
         for f in local_files:
             if f.endswith(".shp"):
                 return f
-        else 
-            raise ValueError(
+        raise ValueError(
             f"No shapefile found in {filelist}, if you are using fsspec caching"
             " consider using same_names=True"
         )

--- a/intake_geopandas/geopandas.py
+++ b/intake_geopandas/geopandas.py
@@ -75,10 +75,10 @@ class GeoPandasFileSource(GeoPandasSource):
         self.storage_options = storage_options or {}
 
         # warn if using fsspec caching and same_names not True for zip files
-        if 'cache' in self.urlpath and 'zip' in self.urlpath:
+        if 'cache::' in self.urlpath and self.urlpath.endswith('zip'):
             same_names = False  # default
             # find different same_names setting
-            for c in ['blockcache', 'filecache', 'simplecache']:
+            for c in ['filecache', 'simplecache']:
                 if c in self.storage_options:
                     if 'same_names' in self.storage_options[c]:
                         same_names = self.storage_options[c]['same_names']
@@ -107,7 +107,7 @@ class GeoPandasFileSource(GeoPandasSource):
                     url = 'zip://'+ url
             elif isinstance(url, list):  # when url is cached unziped
                 url = find_shp(url)
-        print(f'Load from url: {url}')
+
         self._dataframe = geopandas.read_file(
             url, bbox=self._bbox, **self._geopandas_kwargs)
 

--- a/intake_geopandas/geopandas.py
+++ b/intake_geopandas/geopandas.py
@@ -141,7 +141,8 @@ class ShapefileSource(GeoPandasFileSource):
         for f in local_files:
             if f.endswith(".shp"):
                 return f
-        raise ValueError(
+        else 
+            raise ValueError(
             f"No shapefile found in {filelist}, if you are using fsspec caching"
             " consider using same_names=True"
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 intake
-git+git://github.com/geopandas/geopandas@master
+geopandas
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 intake
-geopandas
+git+git://github.com/geopandas/geopandas@master
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 intake
-geopandas
+-e git://github.com/geopandas/geopandas
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 intake
--e git://github.com/geopandas/geopandas.git
+geopandas
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 intake
--e git://github.com/geopandas/geopandas
+-e git://github.com/geopandas/geopandas.git
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 intake
 geopandas
 pytest
+fsspec

--- a/tests/data/shape.catalog.yaml
+++ b/tests/data/shape.catalog.yaml
@@ -7,3 +7,31 @@ sources:
     driver: shape
     args:
       urlpath: '{CATALOG_PATH}/stations/stations.shp'
+
+  MEOW:
+      description: MEOW
+      driver: intake_geopandas.geopandas.ShapefileSource
+      args:
+        urlpath: http://maps.tnc.org/files/shp/MEOW-TNC.zip
+
+
+  MEOW_simplecache:
+    description: caching of the zipfile
+    driver: intake_geopandas.geopandas.ShapefileSource
+    args:
+      urlpath: simplecache::http://maps.tnc.org/files/shp/MEOW-TNC.zip
+      storage_options:
+        simplecache:
+          same_names: True
+          cache_storage: tempfile
+
+
+  ALA_many_shapefiles_in_one_zip:
+    description: gadm36_ALA contains gadm36_ALA_0.shp and gadm36_ALA_1.shp, caches first
+    driver: intake_geopandas.geopandas.ShapefileSource
+    args:
+      urlpath: simplecache::zip://gadm36_ALA_0*::https://biogeo.ucdavis.edu/data/gadm3.6/shp/gadm36_ALA_shp.zip
+      storage_options:
+        simplecache:
+          same_names: True
+          cache_storage: tempfile

--- a/tests/test_remote_cache.py
+++ b/tests/test_remote_cache.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+import os
+import shutil
+
+import pytest
+from fiona.errors import DriverError
+
+from intake_geopandas import GeoJSONSource, ShapefileSource
+
+
+def try_clean_cache(item):
+    c = None
+    for c in ['blockcache', 'filecache', 'simplecache']:
+        if c in item.storage_options:
+            caching = c
+    assert c is not None, 'caching not found'
+    path = item.storage_options[caching]['cache_storage']
+    if isinstance(path, str):
+        if os.path.exists(path):
+            shutil.rmtree(path)
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'http://maps.tnc.org/files/shp/MEOW-TNC.zip',
+        'https://biogeo.ucdavis.edu/data/gadm3.6/shp/gadm36_ALA_shp.zip',
+        'zip://gadm36_ALA_0*::https://biogeo.ucdavis.edu/data/gadm3.6/shp/'
+        'gadm36_ALA_shp.zip',
+    ],
+    ids=['url_zip', 'url_2_shp_zip', 'url_2_shp_extract_one_from_zip'],
+)
+@pytest.mark.parametrize('strategy', ['simplecache', 'filecache'])
+def test_different_cachings_and_url(url, strategy):
+    """Test different caching strategies for different urls."""
+    item = ShapefileSource(
+        f'{strategy}::{url}',
+        storage_options={strategy: {'same_names': True, 'cache_storage': 'tempfile'}},
+    )
+    print(item)
+    expected_location = item.storage_options[strategy]['cache_storage']
+    try_clean_cache(item)
+    assert not os.path.exists(expected_location)
+    item.read()
+    assert os.path.exists(expected_location)
+    try_clean_cache(item)
+
+
+@pytest.mark.parametrize('same_names', [False, True])
+def test_same_name_required_else_warn(same_names):
+    """Test that same_names is required to load zip file from cache. Warns during init
+    if same_names is False for zip file."""
+    ShapefileSource_args = {
+        'urlpath': 'simplecache::http://maps.tnc.org/files/shp/MEOW-TNC.zip',
+        'storage_options': {
+            'simplecache': {'same_names': same_names, 'cache_storage': 'tmpfile'}
+        },
+    }
+    if not same_names:  # initialization warning when same_names False
+        with pytest.warns(UserWarning, match='same_names = True'):
+            item = ShapefileSource(**ShapefileSource_args)
+    else:  # no warning when same_names True
+        item = ShapefileSource(**ShapefileSource_args)
+    expected_location_on_disk = item.storage_options['simplecache']['cache_storage']
+    try_clean_cache(item)
+    assert not os.path.exists(expected_location_on_disk)
+    if not same_names:
+        # fiona expects paths ending with '.zip' or '.shp'
+        with pytest.raises(DriverError):
+            item.read()
+    else:
+        item.read()
+    assert os.path.exists(expected_location_on_disk)
+    try_clean_cache(item)
+    assert not os.path.exists(expected_location_on_disk)
+
+
+@pytest.fixture
+def GeoJSONSource_countries_remote():
+    url = (
+        'simplecache::https://raw.githubusercontent.com/intake/'
+        'intake_geopandas/master/tests/data/countries.geo.json'
+    )
+    return GeoJSONSource(
+        **{
+            'urlpath': url,
+            'storage_options': {'simplecache': {'cache_storage': 'tempfile'}},
+        }
+    )
+
+
+@pytest.mark.parametrize('same_names', [False, True])
+def test_remote_GeoJSONSource(GeoJSONSource_countries_remote, same_names):
+    """GeoJSONSource works with either `same_names` True or False."""
+    item = GeoJSONSource_countries_remote
+    item.storage_options['simplecache']['same_names'] = same_names
+    expected_location_on_disk = item.storage_options['simplecache']['cache_storage']
+    try_clean_cache(item)
+    assert not os.path.exists(expected_location_on_disk)
+    item.read()
+    assert os.path.exists(expected_location_on_disk)
+    try_clean_cache(item)
+    assert not os.path.exists(expected_location_on_disk)

--- a/tests/test_remote_cache.py
+++ b/tests/test_remote_cache.py
@@ -8,7 +8,7 @@ from intake_geopandas import GeoJSONSource, ShapefileSource
 
 import geopandas
 
-geopandas_version_allows_fsspec_caching = int(geopandas.__version__[:5].replace('.','')) > 80 # checks geopandas larger than 0.8.0
+geopandas_version_allows_fsspec_caching = int(geopandas.__version__[:5].replace('.','')) > 81 # checks geopandas larger than 0.8.0
 
 def try_clean_cache(item):
     c = None

--- a/tests/test_remote_cache.py
+++ b/tests/test_remote_cache.py
@@ -19,7 +19,6 @@ def try_clean_cache(item):
             shutil.rmtree(path)
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize(
     'url',
     [
@@ -87,7 +86,6 @@ def GeoJSONSource_countries_remote():
     )
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize('same_names', [False, True])
 def test_remote_GeoJSONSource(GeoJSONSource_countries_remote, same_names):
     """GeoJSONSource works with either `same_names` True or False."""

--- a/tests/test_remote_cache.py
+++ b/tests/test_remote_cache.py
@@ -10,7 +10,7 @@ from intake_geopandas import GeoJSONSource, ShapefileSource
 
 def try_clean_cache(item):
     c = None
-    for c in ['blockcache', 'filecache', 'simplecache']:
+    for c in ['filecache', 'simplecache']:
         if c in item.storage_options:
             caching = c
     assert c is not None, 'caching not found'
@@ -37,7 +37,6 @@ def test_different_cachings_and_url(url, strategy):
         f'{strategy}::{url}',
         storage_options={strategy: {'same_names': True, 'cache_storage': 'tempfile'}},
     )
-    print(item)
     expected_location = item.storage_options[strategy]['cache_storage']
     try_clean_cache(item)
     assert not os.path.exists(expected_location)

--- a/tests/test_remote_cache.py
+++ b/tests/test_remote_cache.py
@@ -6,6 +6,9 @@ import pytest
 
 from intake_geopandas import GeoJSONSource, ShapefileSource
 
+import geopandas
+
+geopandas_version_allows_fsspec_caching = int(geopandas.__version__[:5].replace('.','')) > 80 # checks geopandas larger than 0.8.0
 
 def try_clean_cache(item):
     c = None
@@ -18,7 +21,7 @@ def try_clean_cache(item):
         if os.path.exists(path):
             shutil.rmtree(path)
 
-
+@pytest.mark.skipif(not geopandas_version_allows_fsspec_caching, reason='requires geopandas release after 0.8.0')
 @pytest.mark.parametrize(
     'url',
     [
@@ -85,7 +88,7 @@ def GeoJSONSource_countries_remote():
         }
     )
 
-
+@pytest.mark.skipif(not geopandas_version_allows_fsspec_caching, reason='requires geopandas release after 0.8.0')
 @pytest.mark.parametrize('same_names', [False, True])
 def test_remote_GeoJSONSource(GeoJSONSource_countries_remote, same_names):
     """GeoJSONSource works with either `same_names` True or False."""


### PR DESCRIPTION
closes #15 
similar to #16 

prototyping gist: https://gist.github.com/aaronspring/3a865b991f40fa7b3afef102df0717f8


Background:
- shapefiles are often zip files file.zip containing equally named file.cpg, file.dbf file.prj file.shp file.shx
- geopandas.read_file('file.shp') opens a shapefile
- geopandas.read_file('zip://file.zip') opens a shapefile
- geopandas.read_file('http://remote_file.zip') opens a shapefile

given those requirements I decided for the following Caching strategy:
1. cache with `fsspec.open_local` requiring `same_names=True` to save files with their proper names to disk, warn when `same_names` not given
2. pass local path to `geopandas.read_file`, modify local url to `zip://...file.zip` or choose `file.shp`
3. bypass `fsspec` when no `cache::` in url

i.e. I didnt see a way how to cache and use a `use_fsspec` keyword @ian-r-rose @martindurant 